### PR TITLE
fix the memory leaks

### DIFF
--- a/src/ad.cpp
+++ b/src/ad.cpp
@@ -24,7 +24,7 @@ Ad::Ad(double rate): Plugin<Ad> (p_n_ports)
 	driftCount = 0;
 
 	m_rate = rate;
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 }
 
 void Ad::run(uint32_t nframes)

--- a/src/ad.hpp
+++ b/src/ad.hpp
@@ -27,7 +27,7 @@ class Ad: public Plugin<Ad>
 		float drift_a[MAX_ANALOGUE_DRIVER_OUT], drift_c[MAX_ANALOGUE_DRIVER_OUT];
 		int detuneCount, driftCount;
 		double m_rate;
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/dynamicwaves.cpp
+++ b/src/dynamicwaves.cpp
@@ -16,7 +16,7 @@
 
 DynamicWaves::DynamicWaves(double rate): Plugin<DynamicWaves> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period / 2.0;

--- a/src/dynamicwaves.hpp
+++ b/src/dynamicwaves.hpp
@@ -48,7 +48,7 @@ class DynamicWaves: public Plugin<DynamicWaves>
 		float *expFMData;
 		float *linFMData;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/dynamicwaves2.cpp
+++ b/src/dynamicwaves2.cpp
@@ -16,7 +16,7 @@
 
 DynamicWaves2::DynamicWaves2(double rate): Plugin<DynamicWaves2> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period / 2.0;

--- a/src/dynamicwaves2.hpp
+++ b/src/dynamicwaves2.hpp
@@ -48,7 +48,7 @@ class DynamicWaves2: public Plugin<DynamicWaves2>
 		float *expFMData;
 		float *linFMData;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/fftvocoder.cpp
+++ b/src/fftvocoder.cpp
@@ -13,6 +13,11 @@ FFTVocoder::FFTVocoder(double rate): Plugin<FFTVocoder>(p_n_ports)
 	modmap = 0;
 	armodmap = 0;
 
+	planmodforward = 0;
+	planmodbackward = 0;
+	plancarrforward = 0;
+	plancarrbackward = 0;
+
 	carrinforward = 0;
 	carrinbackward = 0;
 	carroutforward = 0;
@@ -32,6 +37,11 @@ FFTVocoder::~FFTVocoder()
 	free (window);
 	free (modmap);
 	free (armodmap);
+
+	fftw_destroy_plan (planmodforward);
+	fftw_destroy_plan (planmodbackward);
+	fftw_destroy_plan (plancarrforward);
+	fftw_destroy_plan (plancarrbackward);
 
 	fftw_free(carrinforward);
 	fftw_free(carrinbackward);

--- a/src/fftvocoder.cpp
+++ b/src/fftvocoder.cpp
@@ -7,6 +7,21 @@ FFTVocoder::FFTVocoder(double rate): Plugin<FFTVocoder>(p_n_ports)
 {
 	whichwin = 0;
 
+	modbuf = 0;
+	carrbuf = 0;
+	window = 0;
+	modmap = 0;
+	armodmap = 0;
+
+	carrinforward = 0;
+	carrinbackward = 0;
+	carroutforward = 0;
+	carroutbackward = 0;
+	modinforward = 0;
+	modinbackward = 0;
+	modoutforward = 0;
+	modoutbackward = 0;
+
 	p_firstRound = true;
 }
 
@@ -17,6 +32,15 @@ FFTVocoder::~FFTVocoder()
 	free (window);
 	free (modmap);
 	free (armodmap);
+
+	fftw_free(carrinforward);
+	fftw_free(carrinbackward);
+	fftw_free(carroutforward);
+	fftw_free(carroutbackward);
+	fftw_free(modinforward);
+	fftw_free(modinbackward);
+	fftw_free(modoutforward);
+	fftw_free(modoutbackward);
 }
 
 void FFTVocoder::run(uint32_t nframes)
@@ -324,14 +348,14 @@ void FFTVocoder::initial(uint32_t nframes)
 	armodmap = (float *) malloc (sizeof (float) * fftsize);
 
 	//  FFTW setup stuff
-	carrinforward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	carrinbackward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	carroutforward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	carroutbackward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	modinforward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	modinbackward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	modoutforward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
-	modoutbackward = (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * fftsize);
+	carrinforward = fftw_alloc_complex (fftsize);
+	carrinbackward = fftw_alloc_complex (fftsize);
+	carroutforward = fftw_alloc_complex (fftsize);
+	carroutbackward = fftw_alloc_complex (fftsize);
+	modinforward = fftw_alloc_complex (fftsize);
+	modinbackward = fftw_alloc_complex (fftsize);
+	modoutforward = fftw_alloc_complex (fftsize);
+	modoutbackward = fftw_alloc_complex (fftsize);
 
 	fftw_set_timelimit (0.1);
 

--- a/src/synthdata.cpp
+++ b/src/synthdata.cpp
@@ -91,7 +91,7 @@ SynthData::SynthData()
 		wave_tri[l1] = -1.0 + (float) (l1 - (WAVE_PERIOD >> 1) - (WAVE_PERIOD >> 2)) * dy;
 }
 
-float SynthData::exp_table(float x)
+float SynthData::exp_table(float x) const
 {
 	int index;
 
@@ -103,7 +103,7 @@ float SynthData::exp_table(float x)
 	return (exp_data[index]);
 }
 
-float SynthData::exp2_table(float f)
+float SynthData::exp2_table(float f) const
 {
 	if (f < -16)
 		return 0;
@@ -128,3 +128,4 @@ float SynthData::exp2_table(float f)
 	return uexp2.f;
 }
 
+SynthData SynthData::single_instance_;

--- a/src/synthdata.hpp
+++ b/src/synthdata.hpp
@@ -8,9 +8,10 @@
 
 class SynthData
 {
-	public:
+	protected:
 		SynthData();
 
+	public:
 		float wave_sine[WAVE_PERIOD];
 		float wave_saw[WAVE_PERIOD];
 		float wave_saw2[WAVE_PERIOD];
@@ -19,8 +20,13 @@ class SynthData
 		float exp_data[EXP_TABLE_LEN];
 		float exp2_data[EXP2_BUF_LEN];
 
-		float exp_table(float x);
-		float exp2_table(float);
+		float exp_table(float x) const;
+		float exp2_table(float) const;
+
+		static const SynthData &instance() { return single_instance_; }
+
+	private:
+		static SynthData single_instance_;
 };
 
 #endif

--- a/src/vcaexp.cpp
+++ b/src/vcaexp.cpp
@@ -5,7 +5,7 @@
 
 VcaExp::VcaExp(double rate): Plugin<VcaExp>(p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 }
 
 void VcaExp::run(uint32_t nframes)

--- a/src/vcaexp.hpp
+++ b/src/vcaexp.hpp
@@ -12,7 +12,7 @@ class VcaExp: public Plugin<VcaExp>
 		void run(uint32_t nframes);
 
 	private:
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/vcdoubledecay.cpp
+++ b/src/vcdoubledecay.cpp
@@ -7,7 +7,7 @@
 
 VCDoubleDecay::VCDoubleDecay(double rate): Plugin<VCDoubleDecay> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	e = 0;
 	e2 = 0;

--- a/src/vcdoubledecay.hpp
+++ b/src/vcdoubledecay.hpp
@@ -12,7 +12,7 @@ class VCDoubleDecay: public Plugin<VCDoubleDecay>
 		void run(uint32_t nframes);
 
 	private:
-		SynthData *synthdata;
+		const SynthData *synthdata;
 
 		float e, e2, old_e, old_e2, s, old_s;
 		int state;

--- a/src/vcenvii.cpp
+++ b/src/vcenvii.cpp
@@ -7,7 +7,7 @@
 
 VCEnvII::VCEnvII(double rate): Plugin<VCEnvII> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	m_rate = rate;
 

--- a/src/vcenvii.hpp
+++ b/src/vcenvii.hpp
@@ -12,7 +12,7 @@ class VCEnvII: public Plugin<VCEnvII>
 		void run(uint32_t nframes);
 
 	private:
-		SynthData *synthdata;
+		const SynthData *synthdata;
 
 		double m_rate;
 

--- a/src/vcf.cpp
+++ b/src/vcf.cpp
@@ -11,7 +11,7 @@
 
 Vcf::Vcf(double rate): Plugin<Vcf>(p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	vcfTypeUsed = -1;
 

--- a/src/vcf.hpp
+++ b/src/vcf.hpp
@@ -35,7 +35,7 @@ class Vcf : public Plugin<Vcf>
 		float freq_tune, gain_linfm, qr, moog_f, revMoog, moog2times;
 		double b_noise;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 
 		void initBuf();
 };

--- a/src/vco2.cpp
+++ b/src/vco2.cpp
@@ -7,7 +7,7 @@
 
 Vco2::Vco2(double rate): Plugin<Vco2> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period * 0.5f;

--- a/src/vco2.hpp
+++ b/src/vco2.hpp
@@ -31,7 +31,7 @@ class Vco2: public Plugin<Vco2>
 
 		double m_rate;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/vco3.cpp
+++ b/src/vco3.cpp
@@ -7,7 +7,7 @@
 
 Vco3::Vco3(double rate): Plugin<Vco3> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period * 0.5f;

--- a/src/vco3.hpp
+++ b/src/vco3.hpp
@@ -32,7 +32,7 @@ class Vco3: public Plugin<Vco3>
 
 		double m_rate;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/vcorgan.cpp
+++ b/src/vcorgan.cpp
@@ -15,7 +15,7 @@
 
 VCOrgan::VCOrgan(double rate):	Plugin<VCOrgan> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period / 2.0;

--- a/src/vcorgan.hpp
+++ b/src/vcorgan.hpp
@@ -42,7 +42,7 @@ class VCOrgan: public Plugin<VCOrgan>
 		float *expFMData;
 		float *linFMData;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif

--- a/src/vcorgan2.cpp
+++ b/src/vcorgan2.cpp
@@ -15,7 +15,7 @@
 
 VCOrgan2::VCOrgan2(double rate):	Plugin<VCOrgan2> (p_n_ports)
 {
-	synthdata = new SynthData();
+	synthdata = &SynthData::instance();
 
 	wave_period = (float) WAVE_PERIOD;
 	wave_period_2 = wave_period / 2.0;

--- a/src/vcorgan2.hpp
+++ b/src/vcorgan2.hpp
@@ -42,7 +42,7 @@ class VCOrgan2: public Plugin<VCOrgan2>
 		float *expFMData;
 		float *linFMData;
 
-		SynthData *synthdata;
+		const SynthData *synthdata;
 };
 
 #endif


### PR DESCRIPTION
This edit fixes memory leaks in two ways.
I have mentioned the first memory leak bug in https://github.com/blablack/ams-lv2/issues/32.

The synthdata is also leaked. It is a set of tables which plugins generate when they are instantiated.
Valgrind shows this leaks about 5MB per instantiation, which can add up quite fast in real use.
Synthdata only needs to be computed once, so I fix this bug by making it singleton and const.

edit: also clean up FFTW plans